### PR TITLE
converting value to Decimal128 if it is not already one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ var/
 .installed.cfg
 *.egg
 
+.idea
+
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.

--- a/aiomongodel/fields.py
+++ b/aiomongodel/fields.py
@@ -633,6 +633,10 @@ class DecimalField(NumberField):
     def from_mongo(self, value):
         if value is None:
             return None
+
+        if not isinstance(value, Decimal128):
+            value = Decimal128(str(value))
+
         return value.to_decimal()
 
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -281,6 +281,8 @@ def test_field_to_mongo(field, value, expected):
     (EmailField(), 'totti@example.com', 'totti@example.com'),
     (EmailField(), None, None),
     (DecimalField(), Decimal128(Decimal('0.005')), Decimal('0.005')),
+    (DecimalField(), float(0.005), Decimal('0.005')),
+    (DecimalField(), str(0.005), Decimal('0.005')),
     (DecimalField(), None, None),
     (EmbDocField(EmbDoc, allow_none=True), None, None)
 ])


### PR DESCRIPTION
I found an issue, when I was using mongoengine Deicmal field on one project, and then tried to access that same mongo document from another app, which was using aiomongodel DecimalField. 

When saving DecimalField from one project using mongoengine, mongoengine saves that field to mongo as float. 

Then I tried to fetch that document from project which was using aiomongodel and it failed because aiomongodel expected that the value is saved as Decimal128 field.